### PR TITLE
Avoiding conditional directives that split up statements.

### DIFF
--- a/usr/sbin/pkcsslotd/signal.c
+++ b/usr/sbin/pkcsslotd/signal.c
@@ -330,6 +330,7 @@ void slotdGenericSignalHandler( int Signal ) {
 
   int procindex;
   BOOL OkToExit = TRUE;
+  BOOL test_proc_use;
 
   /********************************************************
    *    DbgLog calls (possibly) printf, syslog_r, etc.
@@ -357,11 +358,11 @@ void slotdGenericSignalHandler( int Signal ) {
      if ( shmp == NULL ) {
        break;
      }
-     if ( ( pProc->inuse ) 
+     test_proc_use = pProc->inuse;      
 #if !(NOGARBAGE)
-	   && ( IsValidProcessEntry( pProc->proc_id, pProc->reg_time))
+     test_proc_use = test_proc_use && ( IsValidProcessEntry( pProc->proc_id, pProc->reg_time));
 #endif
-	  ) {
+     if ( test_proc_use ) {
        /* Someone's still using us...  Log it */
        OkToExit = FALSE;
        #ifdef DEV


### PR DESCRIPTION
A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.
- [Linux kernel coding style](https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892)
- [Living in the #ifdef Hell](https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/)

It might improve code understanding, maintainability and error-proneness.
